### PR TITLE
add ddp fallback for adaround

### DIFF
--- a/mqbench/adaround.py
+++ b/mqbench/adaround.py
@@ -152,7 +152,7 @@ def layer_reconstruction(layer, cached_inps, cached_oups, config):
     loss_func = LossFunction(layer=layer, weight=config.weight, max_count=config.max_count, b_range=config.b_range,
                              warm_up=config.warm_up)
 
-    assert USE_LINK or USE_DDP
+    assert USE_LINK or USE_DDP, 'either USE_LINK or USE_DDP should be True'
     world_size = link.get_world_size() if USE_LINK else dist.get_world_size()
 
     logger.info('The world size is {}.'.format(world_size))


### PR DESCRIPTION
It seems `spring.linklink` module isn't provided by default so `adaround.py` could be broken. The fix is mainly based on `sync_tensor`.

But I am not sure how to handle `replace_bn_to_syncbn`, which relies on `SyncBatchNorm2d` from `spring.linklink.nn`. Is https://github.com/yhhhli/BRECQ/blob/44e547f67da9c00bf0b4be078118fed16756a651/linklink/__init__.py#L67 the actual implementation?