### PR TITLE
[Fix]: fix multi input subgraph bug.

### DIFF
--- a/mqbench/utils/hook.py
+++ b/mqbench/utils/hook.py
@@ -22,3 +22,21 @@ class DataSaverHook:
             self.output_store = output_batch
         if self.stop_forward:
             raise StopForwardException
+
+class DataSaveHookByNode:
+    """
+    Forward hook that store a dict with the node as key.
+    """
+    def __init__(self, input_node, output_node, store_input, store_output):
+        self.input_node = input_node
+        self.output_node = output_node 
+        self.store_input = store_input
+        self.store_output = store_output 
+        self.input_store = {}
+        self.output_store = {}
+
+    def __call__(self, module, input_batch, output_batch):
+        if self.store_input:
+            self.input_store.update({self.input_node: input_batch})
+        if self.store_output:
+            self.output_store.update({self.output_node: output_batch})


### PR DESCRIPTION
This bug is due to multiple input nodes are used in the subgraph.
Usually, it is caused by extra inputs like global `dict` which could be
issued by appending it to the subgraph.
But it is worth to note that the `GraphModel`'forward function does not
take args in topology order, which is visible by `model.code`.
To deal with it, pass inputs to the subgraph in a `dict` whose keys are
the `node.name`.
Also the shared nodes like conv2d will make hooks fail because they
record the last input/output only. So cache the inputs only and after
extract the subgraph, compute the fp32/quantized output.