### PR TITLE
[Feature] duplicate the reused nodes in the graph.

### DIFF
--- a/mqbench/prepare_by_platform.py
+++ b/mqbench/prepare_by_platform.py
@@ -309,10 +309,6 @@ def duplicate_reused_nodes(graph: torch.fx.Graph, modules: Dict[str, Any] = {}):
     graph.lint()
     return graph, dup_modules
 
-
-
-
-
 def prepare_by_platform(
         model: torch.nn.Module,
         deploy_backend: BackendType,


### PR DESCRIPTION
Some nodes could be reused to save model size, but it
will cause reconstruction issues, e.g. a node is recon by
many blocks.