### PR TITLE
[Fix] add per-channel load hook to more fake quant.

### DIFF
--- a/mqbench/fake_quantize/adaround_quantizer.py
+++ b/mqbench/fake_quantize/adaround_quantizer.py
@@ -2,7 +2,7 @@ import torch
 from torch.nn.parameter import Parameter
 
 from mqbench.fake_quantize.quantize_base import QuantizeBase
-
+from mqbench.utils.hook import PerChannelLoadHook
 
 _version_under_1100 = int(torch.__version__.split('.')[1]) < 10
 
@@ -48,6 +48,7 @@ class AdaRoundFakeQuantize(QuantizeBase):
         self.register_buffer('scale', torch.tensor([1.0], dtype=torch.float))
         self.register_buffer('zero_point', torch.tensor([0], dtype=torch.int))
         self.adaround = False
+        self.load_state_dict_hook = PerChannelLoadHook(self)
 
     def init(self, weight_tensor: torch.Tensor, round_mode='learned_hard_sigmoid', ):
         self.adaround = True

--- a/mqbench/fake_quantize/dsq.py
+++ b/mqbench/fake_quantize/dsq.py
@@ -4,6 +4,7 @@ import torch
 
 from mqbench.fake_quantize.quantize_base import QuantizeBase
 from mqbench.utils import is_tracing_state
+from mqbench.utils.hook import PerChannelLoadHook
 
 
 def dsq_function_per_tensor(x, scale, zero_point, quant_min, quant_max, alpha):
@@ -44,6 +45,7 @@ class DSQFakeQuantize(QuantizeBase):
         self.register_buffer('scale', torch.tensor([1.0], dtype=torch.float))
         self.register_buffer('zero_point', torch.tensor([0], dtype=torch.int))
         self.alpha = alpha
+        self.load_state_dict_hook = PerChannelLoadHook(self)
 
     def forward(self, X):
         if self.training:

--- a/mqbench/fake_quantize/fixed.py
+++ b/mqbench/fake_quantize/fixed.py
@@ -1,6 +1,7 @@
 import torch
 
 from mqbench.fake_quantize.quantize_base import QuantizeBase
+from mqbench.utils.hook import PerChannelLoadHook
 
 
 _version_under_1100 = int(torch.__version__.split('.')[1]) < 10
@@ -12,6 +13,7 @@ class FixedFakeQuantize(QuantizeBase):
         super(FixedFakeQuantize, self).__init__(observer, **observer_kwargs)
         self.register_buffer('scale', torch.tensor([1.0], dtype=torch.float))
         self.register_buffer('zero_point', torch.tensor([0], dtype=torch.int))
+        self.load_state_dict_hook = PerChannelLoadHook(self)
 
     def forward(self, X):
         if self.observer_enabled[0] == 1:

--- a/mqbench/fake_quantize/tqt.py
+++ b/mqbench/fake_quantize/tqt.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 import torch
 
 from mqbench.fake_quantize.quantize_base import QuantizeBase

--- a/mqbench/utils/hook.py
+++ b/mqbench/utils/hook.py
@@ -50,4 +50,3 @@ class PerChannelLoadHook:
 
     def close(self):
         self.hook.remove()
-

--- a/mqbench/utils/hook.py
+++ b/mqbench/utils/hook.py
@@ -1,3 +1,7 @@
+from functools import partial
+
+import torch
+
 class StopForwardException(Exception):
     """
     Used to throw and catch an exception to stop traversing the graph
@@ -24,3 +28,26 @@ class DataSaverHook:
             self.output_store = output_batch
         if self.stop_forward:
             raise StopForwardException
+
+
+class PerChannelLoadHook:
+    def __init__(self, module):
+        self.hook = module._register_load_state_dict_pre_hook(partial(self.hook_fn, module=module))
+
+    def hook_fn(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs,
+                module):
+        if module.ch_axis == -1:
+            # no per-channel parameters
+            return
+        for module_key, param in module._parameters.items():
+            if module_key not in ["scale", "zero_point"]:
+                continue
+            candidate = prefix + module_key
+            if candidate in state_dict:
+                input_param = state_dict[candidate]
+                if param.shape != input_param.shape:
+                    param.data = torch.ones_like(input_param, dtype=param.dtype, device=param.device)
+
+    def close(self):
+        self.hook.remove()
+


### PR DESCRIPTION
Move per-channel load state dict hook to mqbench.utils.hook.
Add per-channel hook to
	1. adaround
	2. dsq
	3. fixed
Remove from tqt, for it is a per-tensor quantization method.