### PR TITLE
[Fix] Fix the wrong `ch_axis` in `ConvTransposeReLU2d`

### DIFF
--- a/mqbench/nn/intrinsic/qat/modules/deconv_fused.py
+++ b/mqbench/nn/intrinsic/qat/modules/deconv_fused.py
@@ -382,8 +382,6 @@ class ConvTransposeReLU2d(qnnqat.ConvTranspose2d):
                              padding_mode=padding_mode,
                              qconfig=qconfig)
         assert qconfig, 'qconfig must be provided for QAT module'
-        self.qconfig = qconfig
-        self.weight_fake_quant = self.qconfig.weight()
 
     def forward(self, input, output_size=None):
         output_padding = self._output_padding(input, output_size, self.stride,


### PR DESCRIPTION
As discussed in #113 , this PR is to fix the incorrect setting of `ch_axis` in `ConvTransposeReLU2d`.

Thanks~