### PR TITLE
[Fix] mse observer uses per_channel affine

### DIFF
--- a/mqbench/fake_quantize/adaround_quantizer.py
+++ b/mqbench/fake_quantize/adaround_quantizer.py
@@ -1,10 +1,8 @@
 import torch
 from torch.nn.parameter import Parameter
 
-from mqbench.fake_quantize.quantize_base import QuantizeBase
+from mqbench.fake_quantize.quantize_base import QuantizeBase, _version_under_1100 
 from mqbench.utils.hook import PerChannelLoadHook
-
-_version_under_1100 = int(torch.__version__.split('.')[1]) < 10
 
 def _rectified_sigmoid(alpha, zeta, gamma):
     """Function to generate rounding mask.

--- a/mqbench/fake_quantize/quantize_base.py
+++ b/mqbench/fake_quantize/quantize_base.py
@@ -5,6 +5,7 @@ from torch.quantization.fake_quantize import _is_per_channel, _is_per_tensor
 
 from mqbench.utils import is_symmetric_quant
 
+_version_under_1100 = int(torch.__version__.split('.')[1]) < 10
 
 class QuantizeBase(FakeQuantizeBase):
     r""" This is an extension of the FakeQuantize module in fake_quantize.py, which

--- a/mqbench/observer.py
+++ b/mqbench/observer.py
@@ -5,6 +5,7 @@ from typing import Tuple
 import torch
 from torch.quantization.observer import _ObserverBase
 
+from mqbench.fake_quantize.quantize_base import _version_under_1100 
 from mqbench.utils import sync_tensor, pot_quantization, is_symmetric_quant
 from mqbench.utils.logger import logger
 
@@ -545,7 +546,7 @@ class MSEObserver(ObserverBase):
             new_max = x_max * (1.0 - (i * 0.01))
             scale, zero_point = self._calculate_qparams(new_min, new_max)
             x_q = torch.fake_quantize_per_channel_affine(
-                x, scale, zero_point.long(), ch_axis, 
+                x, scale, zero_point.long() if _version_under_1100 else zero_point, ch_axis, 
                 self.quant_min, self.quant_max)
             score = self.lp_loss(x_q, x, reduce_dim)
             update_idx = (score < best_score)
@@ -624,7 +625,7 @@ class EMAMSEObserver(ObserverBase):
             new_max = x_max * (1.0 - (i * 0.01))
             scale, zero_point = self._calculate_qparams(new_min, new_max)
             x_q = torch.fake_quantize_per_channel_affine(
-                x, scale, zero_point.long(), ch_axis, 
+                x, scale, zero_point.long() if _version_under_1100 else zero_point, ch_axis, 
                 self.quant_min, self.quant_max)
             score = self.lp_loss(x_q, x, reduce_dim)
             update_idx = (score < best_score)


### PR DESCRIPTION
(cherry picked from commit d4abf393b017ecb9b470a9824d2a5c0397f082e8)