### PR TITLE
fix deployment problem for tengine_u8 backend

### DIFF
--- a/application/imagenet_example/eval_tengine.py
+++ b/application/imagenet_example/eval_tengine.py
@@ -39,7 +39,14 @@ def infer(engine, inputs: np.ndarray) -> np.ndarray:
         output_tensor = engine.getOutputTensor(0, 0)
         outputs.append(np.array(output_tensor.buf).reshape(1, -1))
 
-    return np.concatenate(outputs)
+    output = np.concatenate(outputs)
+    output_quant_param = engine.getOutputTensor(0, 0).getQuantParam(1)
+    scale, zp = output_quant_param[0][0], output_quant_param[1][0]
+    # de-quantize output
+    if scale != 0:
+        output = (output.astype(np.float32) - zp) * scale
+
+    return output
 
 def validation():
     args = parser.parse_args()

--- a/mqbench/deploy/deploy_tengine.py
+++ b/mqbench/deploy/deploy_tengine.py
@@ -84,11 +84,11 @@ class Tengine_process(LinearQuantizer_process):
                     # by fusing conv+relu, conv+relu6
                     # ref: https://github.com/OAID/Tengine/blob/cdb4ccf77c04a0a771ec6a43631b9d25acd2bae1/tools/convert_tool/utils/graph_optimizer/graph_opt.cpp#L941
                     pre_node = out2node.get(tensor_name, None)
-                    if pre_node and pre_node.op_type in {"Clip", "ReLU"}:
+                    if pre_node and pre_node.op_type in {"Clip", "Relu"}:
                         # suppose onnx version be 11
                         # for relu6
                         if pre_node.op_type == "Clip" and \
-                            not (self.get_constant(out2node[pre_node.input[1]]) == 0 and 
+                            not (self.get_constant(out2node[pre_node.input[1]]) == 0 and
                                  self.get_constant(out2node[pre_node.input[2]]) == 6):
                             continue
 


### PR DESCRIPTION
As mentioned in #166, there is a quantization parameter mismatch problem for the `tengine_u8` backend in the deployment stage.

The direct reason is that there is a typo for ONNX ReLU `op_type` which causes the output quantization parameters of relu cannot be passed to the output quantization parameters of conv in `conv+relu` fusion pattern.

For example, the following is part of resnet18 computation graph represented with ONNX. And we can see that there is a `conv+relu` pattern. Because of layer fusion, we will get output quantization parameters for output tensor `550`.

![image](https://user-images.githubusercontent.com/8266614/184924482-812cfa45-6552-492e-8c4a-152bf554e14d.png)

After converting to tmfile, we can see that `relu` operation is erased from graph. In this case, tengine `quant_tool_uint8` needs output quantization parameters for tensor `549` but which is missing. So we need to pass quantization parameters of `550` to `549` in MQBench `convert_deploy` stage.

![image](https://user-images.githubusercontent.com/8266614/184924094-37cd2259-e690-4921-bf88-bd4a63f492e7.png)

finally, I test `tengine_u8` backend at ImageNet-1k with resnet18. The results are tested in ImageNet-1k full validation sets. 

|  model  |  mode |top1@quantization_simulation   |  top1@tengine_u8  |
| --- | --- | --- | --- |
| resnet18 | uint8 | 69.416 | 69.400| 

